### PR TITLE
Add tests with the Int type defined in Types::Standard

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,6 +15,7 @@ on test => sub {
     requires 'MooseX::Types::Moose';
     requires 'MouseX::Types';
     requires 'MouseX::Types::Mouse';
+    requires 'Type::Tiny', '1.0';
 };
 
 on develop => sub {

--- a/t/020_custom/05_types_standard.t
+++ b/t/020_custom/05_types_standard.t
@@ -1,0 +1,21 @@
+use strict;
+use warnings;
+use Test::Requires { 'Types::Standard' => '1.0' };
+use Smart::Args;
+use Test::More;
+use t::Util;
+use Types::Standard qw(Int);
+use Type::Tiny;
+use Scalar::Util qw(looks_like_number);
+
+lives_ok { foo(foo => 3) };
+is foo(foo => 3), 6;
+throws_ok { foo(foo => 3.14) } qr/Value "3.14" did not pass type constraint "Int"/;
+done_testing;
+exit;
+
+sub foo {
+    args my $foo => Int;
+    $foo*2;
+}
+


### PR DESCRIPTION
The types defined in Types::Standard are compatible with MooseX types,
and therefore can be used with Smart::Args without extra works.

This commits only add a test to reveal such fact.